### PR TITLE
Add readline dependency.

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl3python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl3python3.10.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl3python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl3python3.7.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl3python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl3python3.8.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_openssl3python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_openssl3python3.9.____cpythonpython_implcpython.yaml
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.10.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.7.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.8.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl1.1.1python3.9.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl3python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.10.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl3python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.10.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl3python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.7.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl3python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.7.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl3python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.8.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_openssl3python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.8.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl3python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.9.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
@@ -20,12 +20,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  readline:
+    max_pin: x
   zlib:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
 python_impl:
 - cpython
+readline:
+- '8'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_openssl3python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_openssl3python3.9.____cpythonpython_implcpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@
 
 {% set name = "ndcctools" %}
 {% set version = "7.4.5" %}
-{% set src_checksum = "1425a09550ba67a6b21df9fecc53fe677d3ff5973659bfe53cf8ee6341b00243" % }
+{% set src_checksum = "1425a09550ba67a6b21df9fecc53fe677d3ff5973659bfe53cf8ee6341b00243" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: {{ src_checksum }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [osx and py==27]
   skip: true  # [osx and py==36]
@@ -39,12 +39,14 @@ requirements:
     - zlib
     - libnsl  # [not osx]
     - libopenssl-static
+    - readline
     - openssl
   run:
     - python
     - zlib
     - libnsl  # [not osx]
     - openssl
+    - readline
     - conda-pack
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@
 
 {% set name = "ndcctools" %}
 {% set version = "7.4.5" %}
-{% set src_checksum = "60e862ce2a96c686e9b693e8ac88e914b9c72a810080579125aa7e2a82f9b53b" %}
+{% set src_checksum = "1425a09550ba67a6b21df9fecc53fe677d3ff5973659bfe53cf8ee6341b00243" % }
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Chirp and JX command line tools work much better with readline for editing.
Added readline to main dependency and re-rendered with smithy.
This resulted in new pinned version for readline (seems right) and an update of the osx compiler version from 12 to 13 (@btovar not sure if we want that.)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
